### PR TITLE
(Latest PR) Clean up diagnostic variables in WW3 for Langmuir turbulence parameterization

### DIFF
--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -1,247 +1,125 @@
+cmake_minimum_required(VERSION 3.12)
+project(wav Fortran)
 
-# Open switch file
-file(STRINGS ${CMAKE_BINARY_DIR}/switch switch_strings)
-separate_arguments(switches UNIX_COMMAND ${switch_strings})
+message("Using CIME in ${CIMEROOT} with compiler ${COMPILER}")
 
-# Put executables/libraries into a top-level bin/lib directory within the build directory
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
-# Include list of src files to make file more readable
-# defines variables "ftn_src", "pdlib_src", "scrip_src", and "scripnc_src"
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/src_list.cmake)
-# check_switches as a function for less verbosity in this CMakeLists.txt
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_switches.cmake)
-
-check_switches("${switches}" switch_files)
-
-add_library(ww3_lib STATIC ${ftn_src} ${switch_files})
-# Create alias with same name as exported target
-# so that WW3 can be usead with add_subdirectory
-add_library(WW3::WW3 ALIAS ww3_lib)
-
-# Re-name library on disk to just libww3 instead of libww3_lib
-set_target_properties(ww3_lib PROPERTIES OUTPUT_NAME "ww3")
-set_target_properties(ww3_lib PROPERTIES Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod")
-
-foreach(switch ${switches})
-  target_compile_definitions(ww3_lib PUBLIC W3_${switch})
-endforeach()
-
-if(ENDIAN STREQUAL "BIG")
-  set(endianness "big_endian")
-elseif(ENDIAN STREQUAL "LITTLE")
-  set(endianness "little_endian")
-elseif(ENDIAN STREQUAL "NATIVE")
-  set(endianness "native")
+include(${CASEROOT}/Macros.cmake)
+if (MPILIB STREQUAL mpi-serial)
+  set(CMAKE_Fortran_COMPILER ${SFC})
+  set(CMAKE_C_COMPILER ${SCC})
 else()
-  message(FATAL_ERROR "Unknown option specified by ENDIAN: ${ENDIAN}")
+  set(CMAKE_Fortran_COMPILER ${MPIFC})
+  set(CMAKE_C_COMPILER ${MPICC})
+endif()
+set(CMAKE_Fortran_FLAGS "${FFLAGS} ${CPPDEFS} -I${LIBROOT}/include -I${LIBROOT}/finclude -I${LIBROOT}/nuopc/esmf/${NINST_VALUE}/include")
+
+#-------------------------
+# Set ESMF_F90COMPILEPATHS
+#-------------------------
+# convert esmf.mk makefile variables to cmake variables until ESMF
+# provides proper cmake package
+if (DEFINED ENV{ESMFMKFILE})
+  message("ESMFMKFILE:   $ENV{ESMFMKFILE}")
+else()
+  message(FATAL_ERROR "ESMFMKFILE env variable is not defined")
+endif()
+set(ESMFMKFILE $ENV{ESMFMKFILE})
+file(STRINGS ${ESMFMKFILE} esmf_mk_text)
+foreach(line ${esmf_mk_text})
+  string(REGEX REPLACE "^[ ]+" "" line ${line}) # strip leading spaces
+  if (line MATCHES "^ESMF_*")                   # process only line starting with ESMF_
+    string(REGEX MATCH "^ESMF_[^=]+" esmf_name ${line})
+    string(REPLACE "${esmf_name}=" "" emsf_value ${line})
+    set(${esmf_name} "${emsf_value}")
+  endif()
+endforeach()
+string(REPLACE "-I" "" ESMF_F90COMPILEPATHS ${ESMF_F90COMPILEPATHS})
+string(REPLACE " " ";" ESMF_F90COMPILEPATHS ${ESMF_F90COMPILEPATHS})
+message("ESMF_F90COMPILEPATHS:   ${ESMF_F90COMPILEPATHS}")
+
+#-------------------------
+# Determine switches
+#-------------------------
+list(APPEND switches "CESMCOUPLED" "NCO" "DIST" "MPI" "PR3" "UQ" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB") 
+
+# TODO: need to enamble IC4 with the unstructured implemention  
+if (DEFINED USE_UNSTRUCT)
+  list(APPEND switches "IC0" "PDLIB" "METIS")
+else()
+###  list(APPEND switches "IC4" "OMPG"  "OMPH") 
+  list(APPEND switches "IC0") 
 endif()
 
-add_compile_definitions(ENDIANNESS='${endianness}')
+#-------------------------
+# Include list of src files to make file more readable
+# defines variables "ftn_src", "nuopc_mesh_cap_src", "pdlib_src", "scrip_src", and "scripnc_src"
+#-------------------------
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/src_list.cmake)
 
-target_include_directories(ww3_lib
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
-  $<INSTALL_INTERFACE:mod>)
-
-# Set compiler flags.
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
-  set(compile_flags -no-fma -ip -g -traceback -i4 -real-size 32 -fp-model precise
-    -assume byterecl -fno-alias -fno-fnalias)
-  # -sox only works on Linux
-  if(LINUX)
-    list(APPEND compile_flags -sox)
-  endif()
-  set(compile_flags_release -O3)
-  # SHELL: prefix fixes CMake attempting to de-duplicate the repeated uses of 'all' in -warn, -debug, -check
-  # See https://cmake.org/cmake/help/latest/command/target_compile_options.html#option-de-duplication
-  set(compile_flags_debug -O0 "SHELL:-debug all" "SHELL:-warn all" "SHELL:-check all" -check noarg_temp_created -fp-stack-check -heap-arrays -traceback -fpe0)
-
-  if(APPLE)
-    # The linker on macOS does not include `common symbols` (usually module variables without a default value) by default
-    # Passing the -c flag includes them and fixes an error with undefined symbols
-    # Only ifort marks these symbols as common, compared to GCC
-    set(CMAKE_Fortran_ARCHIVE_FINISH "<CMAKE_RANLIB> -c <TARGET>")
-    set(CMAKE_C_ARCHIVE_FINISH "<CMAKE_RANLIB> -c <TARGET>")
-  endif()
-
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
-  set(compile_flags -g -fno-second-underscore -ffree-line-length-none)
-  set(compile_flags_release -O3)
-  set(compile_flags_debug -Wall -fcheck=all -ffpe-trap=invalid,zero,overflow -frecursive -fbacktrace)
-  
-  if(${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 10)
-    target_compile_options(ww3_lib PUBLIC -fallow-argument-mismatch)
-  endif()
-
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "PGI")
-  set(compile_flags -g -i4 -r4 -Kieee)
-  set(compile_flags_release -O3)
-  set(compile_flags_debug -O0 -Mbounds -Mchkfpstk -Mchkstk -Mdalign -Mdclchk -Mdepchk -Miomutex -Ktrap=fp -Mrecursive -traceback)
-  
-  if(${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 10)
-    target_compile_options(ww3_lib PUBLIC -fallow-argument-mismatch -fallow-invalid-boz)
-  endif()
-
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
-  # TODO: Where do we set -homp for OpenMP compiles?
-  set(compile_flags -g -sdefault32 -eg)
-  set(compile_flags_release -O3)
-  set(compile_flags_debug -O0 -Rbcps -Ktrap=fp)
-endif()
-
-target_compile_options(ww3_lib PUBLIC "$<$<COMPILE_LANGUAGE:Fortran>:${compile_flags}>")
-target_compile_options(ww3_lib PUBLIC "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_debug}>")
-target_compile_options(ww3_lib PUBLIC "$<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_release}>")
-
-# Executables to always build
-set(programs ww3_strt ww3_grid ww3_bound ww3_outf ww3_outp ww3_trck ww3_grib
-  ww3_gint gx_outf gx_outp ww3_uprstr ww3_shel ww3_prep ww3_gspl ww3_multi ww3_systrk)
-
-# Executables to build if NetCDF is found
-set(netcdf_programs ww3_ounf ww3_ounp ww3_bounc ww3_trnc ww3_prnc)
-
-if("OASIS" IN_LIST switches)
-  find_package(OASIS REQUIRED)
-  target_link_libraries(ww3_lib PUBLIC OASIS::OASIS)
-endif()
-
-if(NETCDF)
-  if("netcdf" IN_LIST EXCLUDE_FIND)
-    # NetCDF library flags provided by compiler or wrapper script: don't search
-    set(NetCDF_Fortran_FOUND TRUE)
-    message(WARNING "Not searching for NetCDF library - please ensure correct flags are provided by your compiler/wrapper")
-  else()
-    find_package(NetCDF REQUIRED COMPONENTS Fortran)
-  endif()
-endif()
-
-if(NetCDF_Fortran_FOUND)
-  target_sources(ww3_lib PRIVATE w3ounfmetamd.F90)
-  if(TARGET NetCDF::NetCDF_Fortran)
-    # NetCDF library flags provided by compiler or wrapper script: don't add as dependency
-    target_link_libraries(ww3_lib PUBLIC NetCDF::NetCDF_Fortran)
-  endif()
-  list(APPEND programs ${netcdf_programs})
-endif()
-
-if(UFS_CAP)
-  # Don't search for ESMF if target already exists (when build WW3 as UFS submodule)
-  if (NOT TARGET esmf)
-    find_package(ESMF MODULE REQUIRED)
-  endif()
-
-  if(UFS_CAP STREQUAL "MULTI_ESMF")
-    set(cap_src ${esmf_multi_cap_src})
-  elseif(UFS_CAP STREQUAL "NUOPC_MESH")
-    set(cap_src ${nuopc_mesh_cap_src})
-  endif()
-  
-  target_sources(ww3_lib PRIVATE ${cap_src})
-  target_link_libraries(ww3_lib PUBLIC esmf)
-  # Don't build executables when building WW3 ESMF library
-  set(programs "")
-endif()
-
-set_property(SOURCE w3initmd.F90
-  APPEND
-  PROPERTY COMPILE_DEFINITIONS
-  "__WW3_SWITCHES__=\'${switch_strings}\'"
-  )
-
-if("OMPG" IN_LIST switches)
-  find_package(OpenMP REQUIRED COMPONENTS Fortran)
-  target_link_libraries(ww3_lib PUBLIC OpenMP::OpenMP_Fortran)
-endif()
-
-if("MPI" IN_LIST switches)
-  find_package(MPI REQUIRED COMPONENTS Fortran)
-  target_link_libraries(ww3_lib PUBLIC MPI::MPI_Fortran)
-endif()
+list(APPEND ftn_src ${nuopc_mesh_cap_src})
 
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
+  list(APPEND ftn_src ${pdlib_src})
   if("SCOTCH" IN_LIST switches)
-  find_package(SCOTCH REQUIRED)
-  target_sources(ww3_lib PRIVATE ${pdlib_src})
-  target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)
-elseif("METIS"  IN_LIST switches)
-  find_package(ParMETIS REQUIRED)
-  target_sources(ww3_lib PRIVATE ${pdlib_src})
-  target_link_libraries(ww3_lib PUBLIC ParMETIS::ParMETIS)
+    #find_package(SCOTCH REQUIRED)
+    #target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)
+  elseif("METIS" IN_LIST switches)
+    #find_package(ParMETIS REQUIRED)
+    #target_link_libraries(ww3_lib PUBLIC ParMETIS::ParMETIS)
   else()
-    message(FATAL_ERROR "PDLIB requires METIS or SCOTCH library for domain decomposition")
- endif()
-endif()
-
-if("SCRIP" IN_LIST switches)
-  target_sources(ww3_lib PRIVATE ${scrip_src})
-endif()
-
-
-if("SCRIPNC" IN_LIST switches OR "OASIS" IN_LIST switches OR "TRKNC" IN_LIST switches)
-  if(NOT NetCDF_Fortran_FOUND)
-    message(FATAL_ERROR "Cannot build SCRIPNC, OASIS, or TRKNC without NetCDF")
+     message(FATAL_ERROR "PDLIB requires METIS or SCOTCH library for domain decomposition")
   endif()
 endif()
 
-if("SCRIPNC" IN_LIST switches)
-  target_sources(ww3_lib PRIVATE ${scrip_src} ${scripnc_src})
-endif()
+#-------------------------
+# Determine switch specific files
+# Include check_switches as a function for less verbosity in this CMakeLists.txt
+#-------------------------
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_switches.cmake)
+check_switches("${switches}" switch_files)
 
-if("NCEP2" IN_LIST switches)
-  find_package(g2 REQUIRED)
-  find_package(bacio REQUIRED)
-  find_package(w3emc REQUIRED)
-  target_link_libraries(ww3_lib PUBLIC g2::g2_4 bacio::bacio_4 w3emc::w3emc_4)
-endif()
+message(STATUS "----status of source files-----")
+message(STATUS "list of always source files is : ${ftn_src}")
+message(STATUS "list of switch files is : ${switch_files}")
 
-if("TIDE" IN_LIST switches)
-  list(APPEND programs ww3_prtide)
-endif()
-
-# Executables are not needed when building ww3_multi_esmf library
-foreach(program ${programs})
-  add_executable(${program} ${program}.F90)
-  target_link_libraries(${program} PRIVATE ww3_lib)
+#-------------------------
+# Now check in SourceMods to see if the file should be used instead
+#-------------------------
+list(APPEND srcfiles ${ftn_src} ${switch_files})
+foreach(file ${srcfiles} )
+  if(EXISTS "${CASEROOT}/SourceMods/src.ww3dev/${file}")
+    message("Using ${file} from ${CASEROOT}/SourceMods/src.ww3dev")
+    list(REMOVE_ITEM srcfiles ${file})
+    list(APPEND srcfiles "${CASEROOT}/SourceMods/src.ww3dev/${file}")
+    message(STATUS "Using ${file} from ${CASEROOT}/SourceMods/src.ww3dev")
+  endif()
 endforeach()
 
-install(
-  TARGETS ${programs} ww3_lib
-  EXPORT WW3Exports
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+#-------------------------
+# Determine target library wav
+#-------------------------
+add_library(wav ${srcfiles})
+target_include_directories (wav PRIVATE ${ESMF_F90COMPILEPATHS})
 
-install(FILES ${CMAKE_BINARY_DIR}/switch DESTINATION ${CMAKE_INSTALL_PREFIX})
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod DESTINATION ${CMAKE_INSTALL_PREFIX})
-  
-
-export(EXPORT WW3Exports
-  NAMESPACE WW3::
-  FILE WW3-targets.cmake
+#-------------------------
+# Determine compile definitions for wav
+#-------------------------
+foreach(switch ${switches})
+  target_compile_definitions(wav PUBLIC W3_${switch})
+endforeach()
+add_compile_definitions(ENDIANNESS="big_endian")
+set_property(SOURCE w3initmd.F90
+  APPEND
+  PROPERTY COMPILE_DEFINITIONS
+  "__WW3_SWITCHES__=\'\'"
   )
 
-### Package config
-include(CMakePackageConfigHelpers)
-set(CONFIG_INSTALL_DESTINATION lib/cmake/WW3)
+message("CMAKE_CURRENT_BINARY_DIR is ${CMAKE_CURRENT_BINARY_DIR}")
+message("PROJECT_BINARY_DIR is ${PROJECT_BINARY_DIR}")
 
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/WW3-package-config.cmake.in
-  ${CMAKE_BINARY_DIR}/WW3-config.cmake
-  INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
+# Executables to always build
+add_executable(ww3_grid ww3_grid.F90)
+target_link_libraries(ww3_grid PRIVATE wav)
 
-install(FILES ${CMAKE_BINARY_DIR}/WW3-config.cmake
-  DESTINATION ${CONFIG_INSTALL_DESTINATION})
-
-write_basic_package_version_file(${CMAKE_BINARY_DIR}/WW3-config-version.cmake
-  VERSION ${PROJECT_VERSION}
-  COMPATIBILITY AnyNewerVersion)
-
-install(FILES ${CMAKE_BINARY_DIR}/WW3-config-version.cmake
-  DESTINATION ${CONFIG_INSTALL_DESTINATION})
-
-install(EXPORT WW3Exports
-  NAMESPACE WW3::
-  FILE WW3-targets.cmake
-  DESTINATION ${CONFIG_INSTALL_DESTINATION})
+install(TARGETS wav)

--- a/model/src/w3gdatmd.F90
+++ b/model/src/w3gdatmd.F90
@@ -728,6 +728,9 @@ MODULE W3GDATMD
 #ifdef W3_IS2
     REAL,    POINTER      :: IS2PARS(:)
 #endif
+    LOGICAL               :: LMPENABLED ! flag to enable Li et al. Langmuir parameterization
+    LOGICAL               :: SDTAIL ! flag to enable high-freq tail in Li et al. Stokes Drift computations
+    REAL                  :: HSLMODE ! 0 for test (HSL=10m everywhere, 1 for coupler-based HSL)
     !
     ! unstructured data
     !
@@ -1083,6 +1086,10 @@ MODULE W3GDATMD
 #endif
   INTEGER, POINTER        :: NBEDGE
   INTEGER, POINTER        :: EDGES(:,:), NEIGH(:,:)
+  !
+  LOGICAL, POINTER        :: LMPENABLED
+  LOGICAL, POINTER        :: SDTAIL
+  REAL, POINTER           :: HSLMODE
   !
   ! Variables for unstructured grids
   !
@@ -2274,6 +2281,10 @@ CONTAINS
     USSPF  => GRIDS(IMOD)%USSPF
     USSP_WN => GRIDS(IMOD)%USSP_WN
     FFACBERG => GRIDS(IMOD)%FFACBERG
+    !
+    LMPENABLED => GRIDS(IMOD)%LMPENABLED
+    SDTAIL => GRIDS(IMOD)%SDTAIL
+    HSLMODE => GRIDS(IMOD)%HSLMODE
 #ifdef W3_REF1
     REFLC  => GRIDS(IMOD)%REFLC
     REFLD  => GRIDS(IMOD)%REFLD

--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -1105,6 +1105,7 @@ MODULE W3GRIDMD
        STH1MF, I1STH1M, I2STH1M,                &
        TH2MF, I1TH2M, I2TH2M,                   &
        STH2MF, I1STH2M, I2STH2M
+  NAMELIST /LMPN/ LMPENABLED, SDTAIL, HSLMODE
 #ifdef W3_IS1
   NAMELIST /SIS1/ ISC1, ISC2
 #endif
@@ -2731,6 +2732,11 @@ CONTAINS
     I2STH2M=NK
     !
     FACBERG=1.
+    !
+    LMPENABLED = .false.
+    SDTAIL = .false.
+    HSLMODE = 0   ! 0 for test (HSL=10m everywhere, 1 for coupler-based HSL)
+    !
 #ifdef W3_IS0
     WRITE (NDSO,944)
 #endif
@@ -2882,6 +2888,10 @@ CONTAINS
          IC5MAXKI, IC5MINHW, IC5MAXITER, IC5RKICK, &
          IC5KFILTER, IC5MSTR(NINT(IC5VEMOD))
 #endif
+    !
+    CALL READNL ( NDSS, 'LMPN', STATUS )
+    WRITE (NDSO,4960) STATUS
+    WRITE (NDSO,4961) LMPENABLED, SDTAIL, HSLMODE
     !
     CALL READNL ( NDSS, 'OUTS', STATUS )
     WRITE (NDSO,4970) STATUS
@@ -6673,7 +6683,11 @@ CONTAINS
          /'         (0.0==> no reduction and 1.0==> no wind', &
          /'         input with 100% ice cover)')
     !
-    !
+!
+4960 FORMAT (/'  Langmuir Mixing Parameterization ',A/                   &
+              ' --------------------------------------------------')
+4961 FORMAT ('  &LMPN LMPENABLED = ',L, 'SDTAIL = ', L, ' HSLMODE = ', I2 '/' )
+!
 4970 FORMAT (/'  Spectral output on full grid ',A/                   &
          ' --------------------------------------------------')
 4971 FORMAT ( '       Second order pressure at K=0:',3I4)
@@ -7344,6 +7358,8 @@ CONTAINS
                 READ (NDS,NML=UNST,END=801,ERR=802,IOSTAT=J)
               CASE('OUTS')
                 READ (NDS,NML=OUTS,END=801,ERR=802,IOSTAT=J)
+              CASE('LMPN')
+                READ (NDS,NML=LMPN,END=801,ERR=802,IOSTAT=J)
               CASE('MISC')
                 READ (NDS,NML=MISC,END=801,ERR=802,IOSTAT=J)
               CASE DEFAULT

--- a/model/src/w3idatmd.F90
+++ b/model/src/w3idatmd.F90
@@ -94,9 +94,8 @@ MODULE W3IDATMD
   !      FLCUR     Log.  Public   Flag for current input.
   !      FLWIND    Log.  Public   Flag for wind input.
   !      FLICE     Log.  Public   Flag for ice input.
-#ifdef W3_CESMCOUPLED
-  !      HML       R.A.  Public   Mixed layer depth
-#endif
+  !      HSL       R.A.  Public   Depth of a surface layer over which Stokes
+  !                               drift is averaged
   !      FLTAUA    Log.  Public   Flag for atmospheric momentum input
   !      FLRHOA    Log.  Public   Flag for air density input
   !      INFLAGS1  L.A.  Public   Array consolidating the above six
@@ -219,9 +218,7 @@ MODULE W3IDATMD
     REAL, POINTER         :: CYTIDE(:,:,:,:)
     REAL, POINTER         :: WLTIDE(:,:,:,:)
 #endif
-#ifdef W3_CESMCOUPLED
-    REAL, POINTER         :: HML(:,:)
-#endif
+    REAL, POINTER         :: HSL(:,:)
     LOGICAL               :: IINIT
 #ifdef W3_WRST
     LOGICAL               :: WRSTIINIT=.FALSE.
@@ -272,9 +269,7 @@ MODULE W3IDATMD
   LOGICAL, POINTER        ::  FLLEVTIDE, FLCURTIDE,  &
        FLLEVRESI, FLCURRESI
 #endif
-#ifdef W3_CESMCOUPLED
-  REAL   , POINTER        :: HML(:,:)
-#endif
+  REAL , POINTER :: HSL(:,:)
   !/
 CONTAINS
   !/ ------------------------------------------------------------------- /
@@ -743,10 +738,8 @@ CONTAINS
       CHECK_ALLOC_STATUS ( ISTAT )
     END IF
     !
-#ifdef W3_CESMCOUPLED
-    ALLOCATE ( INPUTS(IMOD)%HML(NX,NY), STAT=ISTAT )
+    ALLOCATE ( INPUTS(IMOD)%HSL(NX,NY), STAT=ISTAT )
     CHECK_ALLOC_STATUS ( ISTAT )
-#endif
     !
     INPUTS(IMOD)%IINIT  = .TRUE.
     !
@@ -1061,9 +1054,7 @@ CONTAINS
         ICEI   => INPUTS(IMOD)%ICEI
         BERGI  => INPUTS(IMOD)%BERGI
       END IF
-#ifdef W3_CESMCOUPLED
-      HML    => INPUTS(IMOD)%HML
-#endif
+      HSL => INPUTS(IMOD)%HSL
       !
       IF ( FLTAUA  ) THEN
         UX0    => INPUTS(IMOD)%UX0

--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -2152,10 +2152,7 @@ CONTAINS
          TAUOCX, TAUOCY, WNMEAN
 #endif
 
-#ifdef W3_CESMCOUPLED
-    USE W3ADATMD, ONLY: LANGMT, LAPROJ, ALPHAL, LASL, LASLPJ,  &
-         ALPHALS, LAMULT
-#endif
+    USE W3ADATMD, ONLY: USSHX, USSHY
 
 #ifdef W3_MPI
     USE W3GDATMD, ONLY: NK
@@ -2248,7 +2245,7 @@ CONTAINS
            0                 +    0  +    0  +  &  ! group 3 (extra contributions below)
            2+(NOGE(4)-2)*(NOSWLL+1) +    0  +    0  +  &  ! group 4
            11                +    3  +    1  +  &  ! group 5
-           12                +    7  +    1  +  &  ! group 6 (extra contributions below)
+           10                +    7  +    1  +  &  ! group 6 (extra contributions below)
            5                 +    4  +    1  +  &  ! group 7
            5                 +    2  +    0  +  &  ! group 8
            5                 +    0  +    0  +  &  ! group 9
@@ -2262,6 +2259,7 @@ CONTAINS
       IF ( FLGRDALL( 6,9)) NRQMAX = NRQMAX + P2MSF(3) - P2MSF(2) + 1
       IF ( FLGRDALL( 6, 8) ) NRQMAX = NRQMAX + 2*NK
       IF ( FLGRDALL( 6,12) ) NRQMAX = NRQMAX + 2*NK
+      IF ( FLGRDALL( 6,14) ) NRQMAX = NRQMAX + 2
       !
       IF ( NRQMAX .GT. 0 ) THEN
         ALLOCATE ( OUTPTS(IMOD)%OUT1%IRQGO(NRQMAX) )
@@ -3218,17 +3216,22 @@ CONTAINS
 #ifdef W3_MPI
         END IF
         !
-#ifdef W3_CESMCOUPLED
         IF ( FLGRDALL( 6, 14) ) THEN
           IH     = IH + 1
           IT     = IT + 1
-          CALL MPI_SEND_INIT (LANGMT(1),NSEALM , MPI_REAL, IROOT,   &
+          CALL MPI_SEND_INIT (USSHX (1),NSEALM , MPI_REAL, IROOT,   &
+               IT, MPI_COMM_WAVE, IRQGO(IH), IERR)
+#ifdef W3_MPIT
+          WRITE (NDST,9011) IH, ' 6/14', IROOT, IT, IRQGO(IH), IERR
+#endif
+          IH     = IH + 1
+          IT     = IT + 1
+          CALL MPI_SEND_INIT (USSHY (1),NSEALM , MPI_REAL, IROOT,   &
                IT, MPI_COMM_WAVE, IRQGO(IH), IERR)
 #ifdef W3_MPIT
           WRITE (NDST,9011) IH, ' 6/14', IROOT, IT, IRQGO(IH), IERR
 #endif
         END IF
-#endif !W3_CESMCOUPLED
         IF ( FLGRDALL( 7, 1) ) THEN
           IH     = IH + 1
           IT     = IT + 1
@@ -4462,17 +4465,23 @@ CONTAINS
 #ifdef W3_MPI
           END IF
           !
-#ifdef W3_CESMCOUPLED
           IF ( FLGRDALL( 6, 14) ) THEN
             IH     = IH + 1
             IT     = IT + 1
-            CALL MPI_RECV_INIT (LANGMT(I0),1,WW3_FIELD_VEC, IFROM, IT,  &
-                 MPI_COMM_WAVE, IRQGO2(IH), IERR)
+            CALL MPI_RECV_INIT (USSHX (I0),1,WW3_FIELD_VEC, IFROM, IT,  &
+                 MPI_COMM_WAVE, IRQGO2(IH), IERR )
+#ifdef W3_MPIT
+            WRITE (NDST,9011) IH, ' 6/14', IFROM, IT, IRQGO2(IH), IERR
+#endif
+            IH     = IH + 1
+            IT     = IT + 1
+            CALL MPI_RECV_INIT (USSHY (I0),1,WW3_FIELD_VEC, IFROM, IT,  &
+                 MPI_COMM_WAVE, IRQGO2(IH), IERR )
 #ifdef W3_MPIT
             WRITE (NDST,9011) IH, ' 6/14', IFROM, IT, IRQGO2(IH), IERR
 #endif
           END IF
-#endif ! W3_CESMCOUPLED
+          !
           IF ( FLGRDALL( 7, 1) ) THEN
             IH     = IH + 1
             IT     = IT + 1

--- a/model/src/w3iogomd.F90
+++ b/model/src/w3iogomd.F90
@@ -1084,6 +1084,9 @@ CONTAINS
     CASE('TOC')
       I = 6
       J = 13
+    CASE('USSH')
+      I = 6
+      J = 14
       !
       ! Group 7
       !
@@ -1296,23 +1299,11 @@ CONTAINS
          ICPRT, DTPRT, WSCUT, NOSWLL, FLOGRD, FLOGR2,&
          NOGRP, NGRPP
     USE W3ADATMD, ONLY: NSEALM
-#ifdef W3_CESMCOUPLED
-    ! USSX, USSY   : surface Stokes drift (SD)
-    ! USSXH, USSYH : surface layer (SL) averaged SD
-    ! LANGMT       : La_t
-    ! LAPROJ       : La_{Proj}
-    ! LASL         : La_{SL}
-    ! LASLPJ       : La_{SL,Proj}
-    ! ALPHAL       : angle between wind and Langmuir cells (SL averaged)
-    ! ALPHALS      : angle between wind and Langmuir cells (surface)
-    ! UD           : wind direction
-    ! LAMULT       : enhancement factor
-    ! HML          : mixing layer depth (from coupler)
-    USE W3ADATMD, ONLY: LAMULT, USSXH, USSYH, LANGMT, LAPROJ, &
-         ALPHAL, ALPHALS, LASL, UD, LASLPJ
-    USE W3IDATMD, ONLY: HML
-    USE W3WDATMD, ONLY: ASF
-#endif
+      ! USSHX, USSHY : surface layer (SL) averaged SD
+      ! HSL          : surface layer depth (1/5 of the mixed layer depth
+      !                from the coupler)
+    USE W3ADATMD, ONLY: USSHX, USSHY
+    USE W3IDATMD, ONLY: HSL
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
@@ -1370,17 +1361,12 @@ CONTAINS
     REAL                       USSCO, FT1
     REAL, SAVE              :: HSMIN = 0.01
     LOGICAL                 :: FLOLOC(NOGRP,NGRPP)
-#ifdef W3_CESMCOUPLED
     ! SWW: angle between wind and waves
-    ! HSL: surface layer depth (=0.2*HML)
-    REAL                    :: SWW !angle between wind and waves
-    REAL                    :: HSL !surface layer depth (=0.2*HML)
-    ! tmp variables for surface and SL averaged SD
-    REAL                    :: ETUSSX(NSEAL),        &
-         ETUSSY(NSEAL),        &
-         ETUSSXH(NSEAL),       &
-         ETUSSYH(NSEAL)
-#endif
+    ! LHSL: local surface layer depth
+    REAL                    :: SWW
+    REAL                    :: LHSL
+    ! tmp variable for surface layer averaged Stokes drift
+    REAL                    :: USSCOH
     !/
     !/ ------------------------------------------------------------------- /
     !/
@@ -1487,25 +1473,10 @@ CONTAINS
     QP    = UNDEF
     WBT    = UNDEF
     !
-#ifdef W3_CESMCOUPLED
-    ETUSSX  = 0.
-    ETUSSY  = 0.
     ETUSCX  = 0.
     ETUSCY  = 0.
-    ETUSSXH  = 0.
-    ETUSSYH  = 0
-    LANGMT = UNDEF
-    LAPROJ = UNDEF
-    LASL   = UNDEF
-    LASLPJ = UNDEF
-    ALPHAL = UNDEF
-    ALPHALS = UNDEF
-    USSX   = 0.
-    USSY   = 0.
-    USSXH  = 0.
-    USSYH  = 0.
-    LAMULT  = 1.
-#endif
+    USSHX  = 0.
+    USSHY  = 0.
     !
     ! 2.  Integral over discrete part of spectrum ------------------------ *
     !
@@ -1631,12 +1602,16 @@ CONTAINS
           TPMS(JSEA) = TPI/SIG(IK)
         END IF
 
-#ifdef W3_CESMCOUPLED
-        ! Get surface layer depth
-        IX    = MAPSF(ISEA,1)
-        IY    = MAPSF(ISEA,2)
-        HSL   = HML(IX,IY)/5.     ! depth over which SD is averaged
-#endif
+         IF (LMPENABLED) then
+            IF (HSLMODE.EQ.0) then
+              LHSL = 10.0 ! a constant value for testing purposes
+            ELSE
+              ! Get surface layer depth from coupler
+              IX    = MAPSF(ISEA,1)
+              IY    = MAPSF(ISEA,2)
+              LHSL  = HSL(IX,IY)      ! depth over which SD is averaged
+              END IF
+            END IF
 
         !
         ! Directional moments in the last freq. band
@@ -1677,39 +1652,14 @@ CONTAINS
           USSCO=FKD*SIG(IK)*WN(IK,ISEA)*COSH(2.*KD)
           BHD(JSEA) = BHD(JSEA) +                             &
                GRAV*WN(IK,ISEA) * EBD(IK,JSEA) / (SINH(2.*KD))
-#ifdef W3_CESMCOUPLED
-          ! Surface Stokes Drift
-          ETUSSX(JSEA)  = ETUSSX(JSEA) + ABX(JSEA)*FACTOR*SIG(IK) &
-               *WN(IK,ISEA)*COSH(2*WN(IK,ISEA)*DW(ISEA))          &
-               /(SINH(WN(IK,ISEA)*DW(ISEA)))**2
-          ETUSSY(JSEA)  = ETUSSY(JSEA) + ABY(JSEA)*FACTOR*SIG(IK) &
-               *WN(IK,ISEA)*COSH(2*WN(IK,ISEA)*DW(ISEA))          &
-               /(SINH(WN(IK,ISEA)*DW(ISEA)))**2
-          ! Depth averaged Stokes Drift
-          ETUSSXH(JSEA)  = ETUSSXH(JSEA) + ABX(JSEA)*FACTOR*SIG(IK) &
-               *(1.-EXP(-2.*WN(IK,ISEA)*HSL))/2./HSL                &
-               *COSH(2*WN(IK,ISEA)*DW(ISEA))                        &
-               /(SINH(WN(IK,ISEA)*DW(ISEA)))**2
-          ETUSSYH(JSEA)  = ETUSSYH(JSEA) + ABY(JSEA)*FACTOR*SIG(IK) &
-               *(1.-EXP(-2.*WN(IK,ISEA)*HSL))/2./HSL                &
-               *COSH(2*WN(IK,ISEA)*DW(ISEA))                        &
-               /(SINH(WN(IK,ISEA)*DW(ISEA)))**2
-#endif
+          IF (LMPENABLED) THEN
+            USSCOH=0.5*FKD*SIG(IK)*(1.-EXP(-2.*WN(IK,ISEA)*LHSL))/LHSL*COSH(2.*KD)
+            ENDIF
         ELSE
           USSCO=FACTOR*SIG(IK)*2.*WN(IK,ISEA)
-#ifdef W3_CESMCOUPLED
-          ! deep water limit
-          ! Surface Stokes Drift
-          ETUSSX(JSEA)  = ETUSSX(JSEA) + ABX(JSEA)*FACTOR*SIG(IK) &
-               *2.*WN(IK,ISEA)
-          ETUSSY(JSEA)  = ETUSSY(JSEA) + ABY(JSEA)*FACTOR*SIG(IK) &
-               *2.*WN(IK,ISEA)
-          ! Depth averaged Stokes Drift
-          ETUSSXH(JSEA)  = ETUSSXH(JSEA) + ABX(JSEA)*FACTOR*SIG(IK) &
-               *(1.-EXP(-2.*WN(IK,ISEA)*HSL))/HSL
-          ETUSSYH(JSEA)  = ETUSSYH(JSEA) + ABY(JSEA)*FACTOR*SIG(IK) &
-               *(1.-EXP(-2.*WN(IK,ISEA)*HSL))/HSL
-#endif
+          IF (LMPENABLED) THEN
+            USSCOH=FACTOR*SIG(IK)*(1.-EXP(-2.*WN(IK,ISEA)*LHSL))/LHSL
+            ENDIF
         END IF
         !
         ABXX(JSEA)   = MAX ( 0. , ABXX(JSEA) ) * FACTOR
@@ -1725,6 +1675,10 @@ CONTAINS
         !
         USSX(JSEA)  = USSX(JSEA) + ABX(JSEA)*USSCO
         USSY(JSEA)  = USSY(JSEA) + ABY(JSEA)*USSCO
+        IF (LMPENABLED) THEN
+          USSHX(JSEA) = USSHX(JSEA) + ABX(JSEA)*USSCOH
+          USSHY(JSEA) = USSHY(JSEA) + ABY(JSEA)*USSCOH
+          ENDIF
         !
         ! Fills the 3D Stokes drift spectrum array
         !  ! The US3D Stokes drift specrum array is now calculated in a
@@ -1998,11 +1952,17 @@ CONTAINS
     !
     DO JSEA=1, NSEAL
       CALL INIT_GET_ISEA(ISEA, JSEA)
-#ifdef W3_CESMCOUPLED
-      IX = MAPSF(ISEA,1)
-      IY = MAPSF(ISEA,2)
-      HS = HML(IX,IY)/5.     ! depth over which SD is averaged
-#endif
+
+      IF (LMPENABLED) then
+        IF (HSLMODE.EQ.0) then
+          LHSL = 10.0 ! a constant value for testing purposes
+        ELSE
+          ! Get surface layer depth from coupler
+          IX    = MAPSF(ISEA,1)
+          IY    = MAPSF(ISEA,2)
+          LHSL  = HSL(IX,IY)      ! depth over which SD is averaged
+          END IF
+        END IF
       !
       ! 3.a Directional mss parameters
       !     NB: the slope PDF is proportional to ell1=ETYY*EC2-2*ETXY*ECS+ETXX*ES2 = C*EC2-2*B*ECS+A*ES2
@@ -2032,16 +1992,23 @@ CONTAINS
       SXX(JSEA) = SXX(JSEA) + FTE * ABXX(JSEA) / CG(NK,ISEA)
       SYY(JSEA) = SYY(JSEA) + FTE * ABYY(JSEA) / CG(NK,ISEA)
       SXY(JSEA) = SXY(JSEA) + FTE * ABXY(JSEA) / CG(NK,ISEA)
-#ifdef W3_CESMCOUPLED
-      ! tail for SD
-      ETUSSX(JSEA)  = ETUSSX(JSEA) + 2*GRAV*ETUSCX(JSEA)/SIG(NK)
-      ETUSSY(JSEA)  = ETUSSY(JSEA) + 2*GRAV*ETUSCY(JSEA)/SIG(NK)
-#endif
       !
       ! Tail for surface stokes drift is commented out: very sensitive to tail power
       !
       !       USSX(JSEA)  = USSX(JSEA) + 2*GRAV*ETUSCX(JSEA)/SIG(NK)
       !       USSY(JSEA)  = USSY(JSEA) + 2*GRAV*ETUSCY(JSEA)/SIG(NK)
+
+      ! Add tail contribution for surface and layer averaged Stokes drift
+      IF (LMPENABLED.and.SDTAIL) then
+        USSX(JSEA)  = USSX(JSEA) + 2*GRAV*ETUSCX(JSEA)/SIG(NK)
+        USSY(JSEA)  = USSY(JSEA) + 2*GRAV*ETUSCY(JSEA)/SIG(NK)
+        USSHX(JSEA) = USSHX(JSEA) + 2*GRAV*ETUSCX(JSEA)/SIG(NK)     &
+          *(1.-(1.-4.*LHSL*WN(NK,ISEA))*EXP(-2.*WN(NK,ISEA)*LHSL))    &
+          /6./WN(NK,ISEA)/LHSL
+        USSHY(JSEA)  = USSHY(JSEA) + 2*GRAV*ETUSCY(JSEA)/SIG(NK)    &
+          *(1.-(1.-4.*LHSL*WN(NK,ISEA))*EXP(-2.*WN(NK,ISEA)*LHSL))    &
+          /6./WN(NK,ISEA)/LHSL
+        END IF
       UBS(JSEA) = UBS(JSEA) + FTWL * EBAND/GRAV
     END DO
     !
@@ -2110,87 +2077,6 @@ CONTAINS
           T02(JSEA) = TPI / SIG(NK)
           T01(JSEA)= T02(JSEA)
         ENDIF
-#ifdef W3_CESMCOUPLED
-        !TODO is this affected by the NXXX vs. NSEALM?
-        ! Should LAMULT, etc. be NSEAML length?
-        ! Output Stokes drift and Langmuir numbers
-        ! USERO(JSEA,1) = HS(JSEA) / MAX ( 0.001 , DW(JSEA) )
-        ! USERO(JSEA,2) = ASF(ISEA)
-        IF (ETUSSX(JSEA) .NE. 0. .OR. ETUSSY(JSEA) .NE. 0.) THEN
-
-          USSX(JSEA) = ETUSSX(JSEA)
-          USSY(JSEA) = ETUSSY(JSEA)
-          USSXH(JSEA) = ETUSSXH(JSEA)
-          USSYH(JSEA) = ETUSSYH(JSEA)
-
-          ! this check is to divide by zeror error with gx17
-          ! is there a better way to do this check?
-          IF( SQRT(USSX(JSEA)**2 + USSY(JSEA)**2) .GT. 0) THEN
-            IF( SQRT(USSXH(JSEA)**2+USSYH(JSEA)**2) .GT. 0) THEN
-
-              LANGMT(JSEA) = SQRT ( UST(ISEA) * ASF(ISEA)        &
-                   * SQRT ( DAIR / DWAT )                   &
-                   / SQRT ( USSX(JSEA)**2 + USSY(JSEA)**2 ) )
-              ! Calculating Langmuir Number for misaligned wind and waves
-              ! see Van Roekel et al., 2012
-              ! take z1 = 4 * HS
-              ! SWW: angle between Stokes drift and wind
-
-              ! no Stokes depth
-              SWW = ATAN2(USSY(JSEA),USSX(JSEA)) - UD(ISEA)
-              ! ALPHALS: angle between wind and LC direction, Surface
-              ! Stokes drift
-              ! LR check for divide by zero
-              if ((LANGMT(JSEA)**2  &
-                   /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)).eq.0.) then
-                print *, 'LR warning A denom 0.'
-                ! This appears to be a decimal precision error
-                ! The first term equals minus the second term to 6 decimal places
-                ! The denominator should be a very small number (e-7)
-                ! ATAN(sin(sww)/small number) tends to pi/2
-                ! So I hardcoded this here.
-                ALPHALS(JSEA) = -1.5707956594501575
-              else
-
-                ALPHALS(JSEA) = ATAN(SIN(SWW) / (LANGMT(JSEA)**2  &
-                     /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)))
-              end if
-
-
-              ALPHALS(JSEA) = ATAN( SIN(SWW) / ( LANGMT(JSEA)**2  &
-                   /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)))
-              LAPROJ(JSEA) = LANGMT(JSEA) &
-                   * SQRT(ABS(COS(ALPHALS(JSEA))) &
-                   / ABS(COS(SWW-ALPHALS(JSEA))))
-              ! Stokes depth
-              SWW = ATAN2(USSYH(JSEA),USSXH(JSEA)) - UD(ISEA)
-              ! ALPHAL: angle between wind and LC direction
-
-              ! LR check for divide by zero (same as above)
-              if ((LANGMT(JSEA)**2  &
-                   /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)).eq.0.) then
-                print *, 'LR warning B denom 0.'
-                ALPHAL(JSEA) = -1.5707956594501575
-              else
-
-                ALPHAL(JSEA) = ATAN(SIN(SWW) / (LANGMT(JSEA)**2  &
-                     /0.4*LOG(MAX(ABS(HML(IX,IY)/4./HS(JSEA)),1.0))+COS(SWW)))
-              end if
-              LASL(JSEA) = SQRT(UST(ISEA)*ASF(ISEA)         &
-                   * SQRT(DAIR/DWAT)                       &
-                   / SQRT(USSXH(JSEA)**2+USSYH(JSEA)**2))
-              LASLPJ(JSEA) = LASL(JSEA) * SQRT(ABS(COS(ALPHAL(JSEA))) &
-                   / ABS(COS(SWW-ALPHAL(JSEA))))
-              ! LAMULT
-              LAMULT(JSEA) = MIN(5.0, ABS(COS(ALPHAL(JSEA))) * &
-                   SQRT(1.0+(1.5*LASLPJ(JSEA))**(-2)+(5.4*real(LASLPJ(JSEA),kind=8))**(-4)))
-              ! user defined output
-              USERO(JSEA,1) = HML(IX,IY)
-              !USERO(JSEA,2) = COS(ALPHAL(JSEA)
-            END IF
-          END IF
-        END IF
-#endif
         !
         !  Add here USERO(JSEA,1) ...
         !
@@ -2669,6 +2555,7 @@ CONTAINS
          TH1M, STH1M, TH2M, STH2M, HSIG, PHICE, TAUICE,&
          STMAXE, STMAXD, HMAXE, HCMAXE, HMAXD, HCMAXD,&
          USSP, TAUOCX, TAUOCY
+    USE W3ADATMD, ONLY: USSHX, USSHY
     !/
     USE W3ODATMD, ONLY: NOGRP, NGRPP, IDOUT, UNDEF, NDST, NDSE,     &
          FLOGRD, IPASS => IPASS1, WRITE => WRITE1,   &
@@ -3043,6 +2930,10 @@ CONTAINS
             TAUOCX(ISEA) = UNDEF
             TAUOCY(ISEA) = UNDEF
           END IF
+          IF ( FLOGRD( 6, 14) ) THEN
+            USSHX (ISEA) = UNDEF
+            USSHY (ISEA) = UNDEF
+          END IF
           !
           IF ( FLOGRD( 7, 1) ) THEN
             ABA   (ISEA) = UNDEF
@@ -3366,6 +3257,9 @@ CONTAINS
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 13 ) THEN
               WRITE ( NDSOG ) TAUOCX(1:NSEA)
               WRITE ( NDSOG ) TAUOCY(1:NSEA)
+            ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 14 ) THEN
+              WRITE ( NDSOG ) USSHX(1:NSEA)
+              WRITE ( NDSOG ) USSHY(1:NSEA)
               !
               !     Section 7)
               !
@@ -3707,6 +3601,11 @@ CONTAINS
                    TAUOCX(1:NSEA)
               READ (NDSOG,END=801,ERR=802,IOSTAT=IERR)         &
                    TAUOCY(1:NSEA)
+            ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 14 ) THEN
+              READ (NDSOG,END=801,ERR=802,IOSTAT=IERR)         &
+                   USSHX(1:NSEA)
+              READ (NDSOG,END=801,ERR=802,IOSTAT=IERR)         &
+                   USSHY(1:NSEA)
 
               !
               !     Section 7)

--- a/model/src/w3iogoncdmd.F90
+++ b/model/src/w3iogoncdmd.F90
@@ -60,9 +60,7 @@ contains
     use w3adatmd   , only : cflxymax, cflthmax, cflkmax, p2sms, us3d
     use w3adatmd   , only : th1m, sth1m, th2m, sth2m, hsig, phice, tauice
     use w3adatmd   , only : stmaxe, stmaxd, hmaxe, hcmaxe, hmaxd, hcmaxd, ussp, tauocx, tauocy
-#ifdef W3_CESMCOUPLED
-    use w3adatmd   , only : langmt
-#endif
+    use w3adatmd , only : usshx, usshy
     use wav_grdout , only : varatts, outvars
     use w3timemd   , only : set_user_timestring
     use w3odatmd   , only : time_origin, calendar_name, elapsed_secs
@@ -355,9 +353,8 @@ contains
         if (vname .eq.   'PHICE') call write_var2d(vname, phice    (1:nsea) )
         if (vname .eq.  'TAUOCX') call write_var2d(vname, tauocx   (1:nsea) )
         if (vname .eq.  'TAUOCY') call write_var2d(vname, tauocy   (1:nsea) )
-#ifdef W3_CESMCOUPLED
-        if (vname .eq.  'LANGMT') call write_var2d(vname, langmt   (1:nsea) )
-#endif
+        if (vname .eq.   'USSHX') call write_var2d(vname, usshx    (1:nsea) )
+        if (vname .eq.   'USSHY') call write_var2d(vname, usshy    (1:nsea) )
         ! Group 7
         if (vname .eq.    'ABAX') call write_var2d(vname, aba      (1:nsea), dir=cos(abd(1:nsea)) )
         if (vname .eq.    'ABAY') call write_var2d(vname, aba      (1:nsea), dir=sin(abd(1:nsea)) )

--- a/model/src/w3iogrmd.F90
+++ b/model/src/w3iogrmd.F90
@@ -993,6 +993,16 @@ CONTAINS
          FTWL, FACTI1, FACTI2, FACHFA, FACHFE
 #endif
     !
+    ! Langmuir mixing parameterization --------------
+    IF ( WRITE ) THEN
+      WRITE (NDSM)                                                &
+        LMPENABLED, SDTAIL, HSLMODE
+      ELSE
+        READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                     &
+             LMPENABLED, SDTAIL, HSLMODE
+    END IF
+
+    ! --------------
     !
     ! Output flags for 3D parameters ------------------------------------- *
     !                                                 Module W3GDATMD

--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -328,6 +328,7 @@ CONTAINS
     USE W3PARALL, ONLY: PRINT_MY_TIME
 #endif
     USE w3odatmd, ONLY : RUNTYPE, INITFILE
+    USE w3adatmd, ONLY : USSHX, USSHY
 #ifdef W3_PDLIB
     USE PDLIB_FIELD_VEC
 #endif
@@ -1043,6 +1044,10 @@ CONTAINS
               WRITE(NDSR,ERR=803,IOSTAT=IERR) TAUOCX(1:NSEA)
               WRITE(NDSR,ERR=803,IOSTAT=IERR) TAUOCY(1:NSEA)
             ENDIF
+            IF ( FLOGRR(6,14) ) THEN
+              WRITE(NDSR,ERR=803,IOSTAT=IERR) USSHX(1:NSEA)
+              WRITE(NDSR,ERR=803,IOSTAT=IERR) USSHY(1:NSEA)
+            ENDIF
             IF ( FLOGRR(7,2) ) THEN
               WRITE(NDSR,ERR=803,IOSTAT=IERR) UBA(1:NSEA)
               WRITE(NDSR,ERR=803,IOSTAT=IERR) UBD(1:NSEA)
@@ -1310,6 +1315,17 @@ CONTAINS
               ENDIF
             ENDDO
           ENDIF
+          IF ( FLOGOA(6,14) ) THEN
+            READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
+            READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
+            DO I=1, NSEALM
+              J = IAPROC + (I-1)*NAPROC
+              IF (J .LE. NSEA) THEN
+                USSHX(I) = TMP(J)
+                USSHY(I) = TMP2(J)
+              ENDIF
+            ENDDO
+          ENDIF
           IF ( FLOGOA(7,2) ) THEN
             READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
             READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1393,6 +1409,8 @@ CONTAINS
           UBD     = 0.
           PHIBBL  = 0.
           TAUBBL  = 0.
+          USSHX   = 0.
+          USSHY   = 0.
         ENDIF
 #ifdef W3_T
         WRITE (NDST,9008)

--- a/model/src/w3odatmd.F90
+++ b/model/src/w3odatmd.F90
@@ -891,9 +891,7 @@ CONTAINS
     IDOUT( 6,11)  = 'Wave-ice energy flux'
     IDOUT( 6,12)  = 'Split Surface Stokes'
     IDOUT( 6,13)  = 'Tot wav-ocn mom flux'
-#ifdef W3_CESMCOUPLED
     IDOUT( 6,14)  = 'Turbulent Langmuir number'
-#endif
     !
     ! 7) Wave-bottom layer
     !

--- a/model/src/wav_comp_nuopc.F90
+++ b/model/src/wav_comp_nuopc.F90
@@ -364,7 +364,7 @@ contains
          isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
-      wav_coupling_to_cice=(trim(cvalue)=="true")
+       read(cvalue,*) wav_coupling_to_cice
     end if
     write(logmsg,'(A,l)') trim(subname)//': Wave wav_coupling_to_cice setting is ',wav_coupling_to_cice
     call ESMF_LogWrite(trim(logmsg), ESMF_LOGMSG_INFO)
@@ -552,6 +552,7 @@ contains
     if ( root_task ) then
       write(stdout,'(a)')'      *** WAVEWATCH III Program shell ***      '
       write(stdout,'(a)')'==============================================='
+      write(stdout,'(a,l)')' Wave wav_coupling_to_cice setting is ',wav_coupling_to_cice
     end if
 
     !--------------------------------------------------------------------
@@ -901,6 +902,7 @@ contains
     type(ESMF_State)  :: exportState
     real(r8), pointer :: z0rlen(:)
     real(r8), pointer :: sw_lamult(:)
+    real(r8), pointer :: sw_lasl(:)
     real(r8), pointer :: sw_ustokes(:)
     real(r8), pointer :: sw_vstokes(:)
     real(r8), pointer :: wave_elevation_spectrum(:,:)
@@ -922,6 +924,14 @@ contains
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       sw_lamult (:) = 1.
     endif
+    if (state_fldchk(exportState, 'Sw_lasl')) then
+      call state_getfldptr(exportState, 'Sw_lasl', sw_lasl, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      ! note: the default value of this surface layer averaged Langmuir number
+      ! should be a large number to be consistent with lamult=1., ustokes=0.,
+      ! and vstokes=0.
+      sw_lasl (:) = 1.e6
+    endif
     if (state_fldchk(exportState, 'Sw_ustokes')) then
       call state_getfldptr(exportState, 'Sw_ustokes', sw_ustokes, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
@@ -938,7 +948,7 @@ contains
       call CalcRoughl(z0rlen)
     endif
     if (wav_coupling_to_cice) then
-      call state_getfldptr(exportState, 'wave_elevation_spectrum', wave_elevation_spectrum, rc=rc)
+      call state_getfldptr(exportState, 'Sw_elevation_spectrum', wave_elevation_spectrum, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       wave_elevation_spectrum(:,:) = 0.
     endif

--- a/model/src/wav_grdout.F90
+++ b/model/src/wav_grdout.F90
@@ -4,7 +4,7 @@ module wav_grdout
 
   implicit none
 
-  integer, parameter   :: maxvars = 24         ! maximum number of variables/group
+  integer, parameter   :: maxvars = 25         ! maximum number of variables/group
 
   private ! except
 
@@ -222,7 +222,7 @@ contains
          ]
 
     !  6   Wave-ocean layer
-    gridoutdefs(6,1:24) = [ &
+    gridoutdefs(6,1:25) = [ &
          varatts( "SXY  ", "SXX       ", "Radiation stresses xx                           ", "N m-1     ", "  ", .false.) , &
          varatts( "SXY  ", "SYY       ", "Radiation stresses yy                           ", "N m-1     ", "  ", .false.) , &
          varatts( "SXY  ", "SXY       ", "Radiation stresses xy                           ", "N m-1     ", "  ", .false.) , &
@@ -246,7 +246,8 @@ contains
          varatts( "USP  ", "USSPY     ", "Partitioned surface Stokes drift y              ", "m s-1     ", "p ", .false.) , &
          varatts( "TWC  ", "TAUOCX    ", "Total wave to ocean stress x                    ", "Pa        ", "  ", .false.) , &
          varatts( "TWC  ", "TAUOCY    ", "Total wave to ocean stress y                    ", "Pa        ", "  ", .false.) , &
-         varatts( "LAN  ", "LANGMT    ", "Turbulent Langmuir number (La_t)                ", "nd        ", "  ", .false.)   &
+         varatts( "USSH ", "USSHX     ", "Surface layer averaged Stokes drift x           ", "m s-1     ", "  ", .false.) , &
+         varatts( "USSH ", "USSHY     ", "Surface layer averaged Stokes drift y           ", "m s-1     ", "  ", .false.)   &
          ]
 
     !  7   Wave-bottom layer

--- a/model/src/wav_import_export.F90
+++ b/model/src/wav_import_export.F90
@@ -20,7 +20,7 @@ module wav_import_export
   use wav_shr_mod  , only : chkerr
   use wav_shr_mod  , only : state_diagnose, state_reset, state_getfldptr, state_fldchk
   use wav_shr_mod  , only : wav_coupling_to_cice, nwav_elev_spectrum, merge_import, dbug_flag, multigrid, unstr_mesh
-  use constants    , only : grav, tpi, dwat
+  use constants    , only : grav, tpi, dwat, dair
   use w3parall     , only : init_get_isea
 
   implicit none
@@ -140,9 +140,9 @@ contains
     end if
     if (cesmcoupled) then
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_lamult' )
+      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_lasl' )
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_ustokes')
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_vstokes')
-      !call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_hstokes')
     else
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_z0')
     end if
@@ -154,7 +154,7 @@ contains
     ! will be implemented soon based on receiving USSP and USSPF from the coupler instead of the mod_def file. This will
     ! also ensure compatibility with the ocean component since ocean will also receive these from the coupler.
     if (wav_coupling_to_cice) then
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'wave_elevation_spectrum', &
+      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_elevation_spectrum', &
            ungridded_lbound=1, ungridded_ubound=nwav_elev_spectrum)
     end if
 
@@ -267,7 +267,7 @@ contains
     use w3odatmd    , only: w3seto
     use w3wdatmd    , only: time, w3setw
 #ifdef W3_CESMCOUPLED
-    use w3idatmd    , only: HML
+    use w3idatmd    , only: HSL
 #else
     use wmupdtmd    , only: wmupd2
     use wmmdatmd    , only: wmsetm
@@ -480,8 +480,8 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! ocn mixing layer depth
-    global_data = max(global_data, 5.)
-    call FillGlobalInput(global_data, HML)
+    global_data = max(global_data, 5.)*0.2
+    call FillGlobalInput(global_data, HSL)
 #endif
     ! ---------------
     ! INFLAGS1(5) - atm momentum fields
@@ -588,7 +588,9 @@ contains
     use w3gdatmd      , only : nseal, mapsf, MAPSTA, USSPF, NK, w3setg
     use w3iogomd      , only : CALC_U3STOKES
 #ifdef W3_CESMCOUPLED
-    use w3adatmd      , only : LAMULT
+    use w3wdatmd      , only : ASF, UST
+    use w3adatmd      , only : USSHX, USSHY, UD, HS
+    use w3idatmd      , only : HSL
 #else
     use wmmdatmd      , only : mdse, mdst, wmsetm
 #endif
@@ -600,6 +602,7 @@ contains
     ! Local variables
 #ifdef W3_CESMCOUPLED
     real(R8)          :: fillvalue = 1.0e30_R8                 ! special missing value
+    real(R8)          :: sww, laslpj, alphal
 #else
     real(R8)          :: fillvalue = zero                      ! special missing value
 #endif
@@ -616,6 +619,7 @@ contains
     real(r8), pointer :: syyn(:)
 
     real(r8), pointer :: sw_lamult(:)
+    real(r8), pointer :: sw_lasl(:)
     real(r8), pointer :: sw_ustokes(:)
     real(r8), pointer :: sw_vstokes(:)
 
@@ -653,11 +657,44 @@ contains
         call init_get_isea(isea, jsea)
         ix  = mapsf(isea,1)
         iy  = mapsf(isea,2)
-        if (mapsta(iy,ix) == 1) then
-          sw_lamult(jsea) = LAMULT(jsea)
+        if (mapsta(iy,ix) == 1 .and. HS(jsea) > zero) then
+           sww = atan2(USSHY(jsea),USSHX(jsea)) - UD(isea)
+           alphal = atan( sin(sww) / (                                       &
+                          2.5 * UST(isea)*ASF(isea)*sqrt(dair/dwat)          &
+                        / max(1.e-14, sqrt(USSX(jsea)**2+USSY(jsea)**2))     &
+                        * log(max(1.0, abs(1.25*HSL(ix,iy)/HS(jsea))))       &
+                        + cos(sww)   )                                       &
+                        )
+           ! note: an arbitrary minimum value of 0.2 is set to avoid zero
+           !       Langmuir number which may result from zero surface friction
+           !       velocity but may cause unphysically strong Langmuir mixing
+           laslpj = max( 0.2, sqrt( UST(isea)*ASF(isea)*sqrt(dair/dwat)      &
+                  / max(1.e-14, sqrt(USSHX(jsea)**2+USSHY(jsea)**2)) )       &
+                  * sqrt(abs(cos(alphal))/abs(cos(sww-alphal))) )
+           sw_lamult(jsea) = abs(cos(alphal)) *                              &
+                             sqrt(1.0+(1.5*laslpj)**(-2)+(5.4*laslpj)**(-4))
         else
           sw_lamult(jsea)  = 1.
         endif
+      enddo
+    end if
+    if (state_fldchk(exportState, 'Sw_lasl')) then
+      call state_getfldptr(exportState, 'Sw_lasl', sw_lasl, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      sw_lasl(:) = fillvalue
+      do jsea=1, nseal
+         isea = iaproc + (jsea-1)*naproc
+         ix  = mapsf(isea,1)
+         iy  = mapsf(isea,2)
+         if (mapsta(iy,ix) == 1) then
+            ! note: an arbitrary minimum value of 0.2 is set to avoid zero
+            !       Langmuir number which may result from zero surface friction
+            !       velocity but may cause unphysically strong Langmuir mixing
+            sw_lasl(jsea) = max(0.2, sqrt(UST(isea)*ASF(isea)*sqrt(dair/dwat) &
+                          / max(1.e-14, sqrt(USSHX(jsea)**2+USSHY(jsea)**2))))
+         else
+            sw_lasl(jsea)  = 1.e6
+         endif
       enddo
     end if
 #endif
@@ -729,7 +766,7 @@ contains
       call CalcRadstr2D( va, sxxn, sxyn, syyn)
     end if
     if (wav_coupling_to_cice) then
-      call state_getfldptr(exportState, 'wave_elevation_spectrum', wave_elevation_spectrum, rc=rc)
+      call state_getfldptr(exportState, 'Sw_elevation_spectrum', wave_elevation_spectrum, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       ! Initialize wave elevation spectrum
       wave_elevation_spectrum(:,:) = fillvalue


### PR DESCRIPTION
This the updated PR based on #4 by @qingli411
In addition to the changes by @qingli411 as summarized below, I have added mod_def namelist parameters to control the Langmuir parameterization and eliminated the CESMCOUPLED and SDTAIL ifdefs by replacing them with if statements (with flags from the newly added namelist) wherever applicable.

 # Pull Request Summary
<!-- A short overview of the PR --> 
This PR cleans up the calculation of Stokes drift and other diagnostics variables in WW3 for Langmuir turbulence parameterization in CESM. 

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

* Clean up the calculations of the surface Stokes drift (`USSX` and `USSY`) and surface layer averaged Stokes drift (`USSHX` and `USSHY`). The calculation of surface layer averaged Stokes drift and the tail contributions to both versions of Stokes drift are activated when `W3_CESMCOUPLED` is defined. 
* Change the input field of mixed layer depth `HML` to a more general surface layer depth `HSL`. This depth is used to calculate the surface layer averaged Stokes drift. When used in CESM, the surface layer depth is defined as 1/5 of the mixed layer depth. Now this 1/5 factor is applied to the mixed layer depth when importing the fields in the cap.
* Clean up the diagnostic variables for Langmuir turbulence parameterization. Some variables are intermediate quantities and are not used in the parameterization. These variables are now deleted. The key variable diagnosed in WW3 is the surface layer averaged Stokes drift (`USSHX` and `USSHY`). The Langmuir enhancement factor (`LAMULT`) and the surface layer averaged Langmuir number (`LASL`) are now calculated when they are exported in the cap. `LASL` is needed for the Langmuir induced entrainment parameterization in CVMix but was not there in the cap code. So it is now added following the way `LAMULT` is defined.  
* This PR only changes the diagnostic variables in WW3 and shouldn't change the answers of WW3. Ideally, this PR shouldn't change the diagnostic variables to be used in CESM (`LAMULT`, `LASL`) as well. But given that the calculation of these variables are moved to the cap, and the way division by zero and physically invalid values (both should be rare) are handled, small changes to these variables are expected.
* Labels: _enhancement_?

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->

This PR addresses the following issues.
* https://github.com/NOAA-EMC/WW3/issues/669
* https://github.com/NOAA-EMC/WW3/issues/670
* https://github.com/NOAA-EMC/WW3/issues/671 

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->

Clean up the calculation of Stokes drift and other diagnostic variables for Langmuir turbulence parameterization.