### PR TITLE
Changes to accomodate NorESM WW3_interface changes

### DIFF
--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -40,15 +40,22 @@ message("ESMF_F90COMPILEPATHS:   ${ESMF_F90COMPILEPATHS}")
 #-------------------------
 # Determine switches
 #-------------------------
-list(APPEND switches "CESMCOUPLED" "NCO" "DIST" "MPI" "PR3" "UQ" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB") 
+list(APPEND switches "CESMCOUPLED" "DIST" "MPI" "FLX0" "SEED" "ST4" "STAB0" "NL1" "BT1" "DB1" "MLIM" "FLD2" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB" "IC4" "NCO")
 
-# TODO: need to enamble IC4 with the unstructured implemention  
-if (DEFINED USE_UNSTRUCT)
-  list(APPEND switches "IC0" "PDLIB" "METIS")
+if (DEFINED USE_PR3)
+  list(APPEND switches PR3 UQ)
+elseif (DEFINED USE_PR1)
+  list(APPEND switches PR1)
 else()
-###  list(APPEND switches "IC4" "OMPG"  "OMPH") 
-  list(APPEND switches "IC0") 
+  message(FATAL_ERROR "either USE_PR3 or USE_PR1 must be defined")
 endif()
+
+if (DEFINED USE_UNSTRUCT)
+  list(APPEND switches "PDLIB" "METIS")
+###else()
+###  list(APPEND switches "OMPG"  "OMPH")
+endif()
+
 
 #-------------------------
 # Include list of src files to make file more readable
@@ -76,12 +83,14 @@ endif()
 # Determine switch specific files
 # Include check_switches as a function for less verbosity in this CMakeLists.txt
 #-------------------------
+message(STATUS "switches are : ${switches}")
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_switches.cmake)
 check_switches("${switches}" switch_files)
 
-message(STATUS "----status of source files-----")
+message(STATUS "---")
 message(STATUS "list of always source files is : ${ftn_src}")
 message(STATUS "list of switch files is : ${switch_files}")
+message(STATUS "---")
 
 #-------------------------
 # Now check in SourceMods to see if the file should be used instead

--- a/model/src/w3gdatmd.F90
+++ b/model/src/w3gdatmd.F90
@@ -730,7 +730,7 @@ MODULE W3GDATMD
 #endif
     LOGICAL               :: LMPENABLED ! flag to enable Li et al. Langmuir parameterization
     LOGICAL               :: SDTAIL ! flag to enable high-freq tail in Li et al. Stokes Drift computations
-    REAL                  :: HSLMODE ! 0 for test (HSL=10m everywhere, 1 for coupler-based HSL)
+    INTEGER               :: HSLMODE ! 0 for test (HSL=10m everywhere, 1 for coupler-based HSL)
     !
     ! unstructured data
     !
@@ -1089,7 +1089,7 @@ MODULE W3GDATMD
   !
   LOGICAL, POINTER        :: LMPENABLED
   LOGICAL, POINTER        :: SDTAIL
-  REAL, POINTER           :: HSLMODE
+  INTEGER, POINTER        :: HSLMODE
   !
   ! Variables for unstructured grids
   !

--- a/model/src/wav_shel_inp.F90
+++ b/model/src/wav_shel_inp.F90
@@ -167,6 +167,7 @@ contains
     character(len=80)   :: linein
     character(len=30)   :: ofile ! w3_cou only
     character(len=8)    :: words(7)=''
+    character(len=256)  :: filename
     logical             :: flflg, flhom, tflagi, prtfrm, flgnml, flh(-7:10)
     integer             :: thrlev = 1
     integer             :: time0(2), timen(2), ttime(2)
@@ -258,16 +259,17 @@ contains
     ! Read nml file if available
     !--------------------
 
-    inquire(file=trim(fnmpre)//"ww3_shel.nml", exist=flgnml)
+    filename = trim(fnmpre)//"wav_in"
+    inquire(file=trim(filename), exist=flgnml)
 
     if (flgnml) then
-      open(newunit=ndsi, file=trim(fnmpre)//"ww3_shel.nml", status='old', iostat=ierr)
+      open(newunit=ndsi, file=trim(filename), status='old', iostat=ierr)
 
       !--------------------
       ! Read namelist
       !--------------------
 
-      call w3nmlshel (mpi_comm, ndsi, trim(fnmpre)//'ww3_shel.nml', nml_domain, nml_input, &
+      call w3nmlshel (mpi_comm, ndsi, trim(filename), nml_domain, nml_input, &
            nml_output_type, nml_output_date, nml_homog_count, nml_homog_input, ierr)
 
       !--------------------


### PR DESCRIPTION
- [rename wav_shel.nml as wav_in](https://github.com/ESCOMP/WW3/commit/51abe09c5b9ebc65b999a1c112acd47dcaaf368a)
- [convert HSLMODE to an integer](https://github.com/ESCOMP/WW3/commit/7fc7a643643d676331dc6a1477c85dfe34e90b90)
- [Changes in CMakeLists to accomodate NorESM changes in WW3_interface](https://github.com/ESCOMP/WW3/commit/20e27ef3c8be09500fbc5e062098ec7f3583406a)