### PR TITLE
w3iogomd.F90: fix IF-stmt indention

### DIFF
--- a/model/src/w3iogomd.F90
+++ b/model/src/w3iogomd.F90
@@ -1602,7 +1602,7 @@ CONTAINS
           TPMS(JSEA) = TPI/SIG(IK)
         END IF
 
-         IF (LMPENABLED) then
+        IF (LMPENABLED) then
             IF (HSLMODE.EQ.0) then
               LHSL = 10.0 ! a constant value for testing purposes
             ELSE
@@ -1610,8 +1610,8 @@ CONTAINS
               IX    = MAPSF(ISEA,1)
               IY    = MAPSF(ISEA,2)
               LHSL  = HSL(IX,IY)      ! depth over which SD is averaged
-              END IF
             END IF
+        END IF
 
         !
         ! Directional moments in the last freq. band
@@ -1654,12 +1654,12 @@ CONTAINS
                GRAV*WN(IK,ISEA) * EBD(IK,JSEA) / (SINH(2.*KD))
           IF (LMPENABLED) THEN
             USSCOH=0.5*FKD*SIG(IK)*(1.-EXP(-2.*WN(IK,ISEA)*LHSL))/LHSL*COSH(2.*KD)
-            ENDIF
+          ENDIF
         ELSE
           USSCO=FACTOR*SIG(IK)*2.*WN(IK,ISEA)
           IF (LMPENABLED) THEN
             USSCOH=FACTOR*SIG(IK)*(1.-EXP(-2.*WN(IK,ISEA)*LHSL))/LHSL
-            ENDIF
+          ENDIF
         END IF
         !
         ABXX(JSEA)   = MAX ( 0. , ABXX(JSEA) ) * FACTOR
@@ -1678,7 +1678,7 @@ CONTAINS
         IF (LMPENABLED) THEN
           USSHX(JSEA) = USSHX(JSEA) + ABX(JSEA)*USSCOH
           USSHY(JSEA) = USSHY(JSEA) + ABY(JSEA)*USSCOH
-          ENDIF
+        ENDIF
         !
         ! Fills the 3D Stokes drift spectrum array
         !  ! The US3D Stokes drift specrum array is now calculated in a
@@ -1961,8 +1961,8 @@ CONTAINS
           IX    = MAPSF(ISEA,1)
           IY    = MAPSF(ISEA,2)
           LHSL  = HSL(IX,IY)      ! depth over which SD is averaged
-          END IF
         END IF
+      END IF
       !
       ! 3.a Directional mss parameters
       !     NB: the slope PDF is proportional to ell1=ETYY*EC2-2*ETXY*ECS+ETXX*ES2 = C*EC2-2*B*ECS+A*ES2
@@ -2008,7 +2008,7 @@ CONTAINS
         USSHY(JSEA)  = USSHY(JSEA) + 2*GRAV*ETUSCY(JSEA)/SIG(NK)    &
           *(1.-(1.-4.*LHSL*WN(NK,ISEA))*EXP(-2.*WN(NK,ISEA)*LHSL))    &
           /6./WN(NK,ISEA)/LHSL
-        END IF
+      END IF
       UBS(JSEA) = UBS(JSEA) + FTWL * EBAND/GRAV
     END DO
     !


### PR DESCRIPTION
# Pull Request Summary
Indent formatting for `IF`-block keywords in `w3iogomd.F90`.

## Description
* Provide a detailed description of what this PR does.
  * Corrects some `IF`/`ENDIF` statements that were out of alignment, to be aligned.
* What bug does it fix, or what feature does it add?
  * Fixes formatting. 
* Is a change of answers expected from this PR?
  * No. 

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @alperaltuntas  
* Mention any labels that should be added:
  * NA 
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply:
  * No answer changes expected.

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close. 
  * addresses current comments in main PR noaa-emc/ww3/pull/1034

### Commit Message
w3iogomd.F90:  fix IF-stmt indention

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) **dev/ufs-weather-model** branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * The suite of coupled UFS RT's was run as a sanity check. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No we don't test for formatting.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Standalone has passed a number of times before.  In this case, for formatting, just a sanity check was in order.
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  *  None expected. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
  * [2024-03-20.RegressionTests_hera.log.txt](https://github.com/ESCOMP/WW3/files/14672396/2024-03-20.RegressionTests_hera.log.txt)

