### PR TITLE
make one more guess at restart filename before giving up

### DIFF
--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -480,7 +480,11 @@ CONTAINS
           fname = trim(user_restfname)//trim(user_timestring)
           inquire( file=trim(fname), exist=exists)
           if (.not. exists) then
-            call extcde (60, msg="required initial/restart file " // trim(fname) // " does not exist")
+             fname = trim(initfile)
+             inquire( file=trim(fname), exist=exists)
+             if (.not. exists) then
+                call extcde (60, msg="required initial/restart file " // trim(fname) // " does not exist")
+             endif
           end if
         end if
       else


### PR DESCRIPTION
# Pull Request Summary
Make one final guess at restart filename before giving up.

## Description
The CESM ERI test does a branch run from ref2 to the final case. 
So the ww3 restart filename is that of ref2: eg: `ERI.ne30pg3_t232.BLT1850.derecho_intel.allactive-defaultio.20241216_171210_hirghc.ref2.ww3.r.0003-01-11-00000
`
But the ww3 is only looking for a restart of the same name as the case:
`ERI.ne30pg3_t232.BLT1850.derecho_intel.allactive-defaultio.20241216_171210_hirghc.ww3.r.0003-01-11-00000
`
instead of giving up after not finding that file, this change allows the model to use the initfile variable from the namelist to make one last try at opening a restart file.  This solves the problem with the ERI test. 

No answers are changed

### Issue(s) addressed
fixes CESM ERI test.

### Commit Message
If restart file is not found, try using the initfile from the namelist before giving up.

### Check list  

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

