### PR TITLE
Restore coupled answers: fix ST4 breaking-probability extent + laslpj precision

### DIFF
--- a/model/src/w3src4md.F90
+++ b/model/src/w3src4md.F90
@@ -2318,16 +2318,16 @@ CONTAINS
       END DO
       !
       ! Computes Breaking probability
-      ! NOTE: for PR1 found that BTH occasionally went negative - so implemented the 
-      ! following fix for this
+      ! NOTE: BTH occasionally goes slightly negative; guard SQRT against it.
+      ! BTH/PB are NSPEC-length arrays, so this must be a whole-array operation
+      ! (a loop over IK1:NK would leave most of PB uninitialized). Where BTH >= 0
+      ! this is identical to the original PB = (MAX(SQRT(BTH)-EPSR,0.))**2.
       !
-      do ik = IK1,NK
-         if (BTH(ik) < 0.) then
-            PB(ik) = 0.
-         else
-            PB(ik) = (MAX(SQRT(BTH(ik))-EPSR,0.))**2
-         end if
-      end do
+      where (BTH < 0.)
+         PB = 0.
+      elsewhere
+         PB = (MAX(SQRT(BTH)-EPSR,0.))**2
+      end where
       !
       ! Multiplies by 28.16 = 22.0 * 1.6² * 1/2 with
       !  22.0 (Banner & al. 2000, figure 6)

--- a/model/src/wav_import_export.F90
+++ b/model/src/wav_import_export.F90
@@ -722,8 +722,7 @@ contains
     ! Local variables
 #ifdef W3_CESMCOUPLED
     real(R8)          :: fillvalue = 1.0e30_R8                 ! special missing value
-    real              :: sww, langmt, lasl, alphal
-    real(r8)          :: laslpj
+    real              :: sww, langmt, lasl, laslpj, alphal
 #else
     real(R8)          :: fillvalue = zero                      ! special missing value
 #endif


### PR DESCRIPTION
Two independent fixes needed after the NorESM merge (#42).
Together they restore **bit-for-bit** coupled (DATM+MOM6+CICE+WW3) answers vs the
`alpha09d` baseline. One is a correctness fix; the other is a precision-consistency fix.

**1. `w3src4md.F90` — correctness (the answer-changing bug).**
`PB` and `BTH` are `NSPEC`-length (`NK*NTH`, the full 2-D spectrum). `PB` is zeroed
beforehand, then filled by `do ik = IK1,NK`, which writes only the first ~`NK` spectral
bins and leaves the other ~97% at zero. Downstream `PB` is used whole-array
(`PB = PB*28.16` → `BRLAMBDA = PB/(2π²)` → dissipation), so the ST4 breaking/dissipation
term is effectively dropped across almost the entire spectrum. Replaced with the
equivalent whole-array `where (BTH < 0.) ... elsewhere ...`, which computes all `NSPEC`
bins.

**2. `wav_import_export.F90` — precision consistency (not a correctness fix).**
`laslpj` was declared `real(r8)` while the surrounding Langmuir terms (`langmt`, `lasl`,
`alphal`) are default `real`; the mixed precision perturbed `Sw_lamult`. Declaring
`laslpj` default `real` matches the other locals and the pre-merge code, restoring
`Sw_lamult` bit-for-bit. Note `real(r8)` is if anything marginally *more* accurate. This
change exists only to reproduce the baseline answer, not to improve it. 

testing: aux_ww3.derecho